### PR TITLE
Detect non-v8 flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![NPM version][npm-image]][npm-url] [![Downloads][downloads-image]][npm-url] [![Travis Build Status][travis-image]][travis-url] [![AppVeyor Build Status][appveyor-image]][appveyor-url] [![Coveralls Status][coveralls-image]][coveralls-url] [![Gitter chat][gitter-image]][gitter-url]
 
-Get available v8 flags.
+Get available v8 and Node.js flags.
 
 ## Usage
 ```js

--- a/test/index.js
+++ b/test/index.js
@@ -173,6 +173,15 @@ describe('v8flags', function() {
       done();
     });
   });
+
+  it('should detect non-v8 flags', function(done) {
+    eraseHome();
+    var v8flags = require('../');
+    v8flags(function(err, flags) {
+      expect(flags).toInclude('--no_deprecation');
+      done();
+    });
+  });
 });
 
 describe('config-path', function() {


### PR DESCRIPTION
In particular newer versions of Node.js have a bunch of non-v8 flags that are relevant in particular when using `v8flags` in combination with `flagged-respawn` or `liftoff` (like Gulp does), e.g. `--experimental-modules`.