### PR TITLE
feat: Remove homedir polyfill

### DIFF
--- a/config-path.js
+++ b/config-path.js
@@ -1,6 +1,6 @@
 var os = require('os');
 var path = require('path');
-var userHome = require('homedir-polyfill')();
+var userHome = os.homedir();
 
 var env = process.env;
 var name = 'js-v8flags';

--- a/package.json
+++ b/package.json
@@ -26,9 +26,7 @@
     "pretest": "npm run lint",
     "test": "nyc mocha --async-only"
   },
-  "dependencies": {
-    "homedir-polyfill": "^1.0.3"
-  },
+  "dependencies": {},
   "devDependencies": {
     "async": "^3.2.2",
     "eslint": "^7.32.0",

--- a/test/index.js
+++ b/test/index.js
@@ -59,7 +59,6 @@ function cleanup() {
 
   delete require.cache[require.resolve('../')];
   delete require.cache[require.resolve('../config-path')];
-  delete require.cache[require.resolve('homedir-polyfill')];
 
   delete process.versions.electron;
 }
@@ -240,8 +239,10 @@ describe('config-path', function () {
 
   it('should return fallback path when homedir is falsy', function (done) {
     var configPath = proxyquire('../config-path.js', {
-      'homedir-polyfill': function () {
-        return null;
+      'os': {
+        homedir: function () {
+          return null;
+        }
       },
     })('win32');
 


### PR DESCRIPTION
We don't need to rely on this polyfill anymore (now that we only support node 10+)