### PR TITLE
feat!: Utilize process.allowedNodeEnvironmentFlags

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -117,7 +117,7 @@ describe('v8flags', function () {
     });
   });
 
-  it('will not throw on non-matching return from node --v8-options', function (done) {
+  it('always has node flags, even when non-matching return from node --v8-options', function (done) {
     if (os.platform() === 'win32') {
       this.skip();
     }
@@ -132,7 +132,7 @@ describe('v8flags', function () {
 
     v8flags(function (err, flags) {
       expect(err).toBeNull();
-      expect(flags).toEqual([]);
+      expect(flags).toEqual(Array.from(process.allowedNodeEnvironmentFlags));
       // Restore original execPath
       process.execPath = execPath;
       done();
@@ -185,7 +185,7 @@ describe('v8flags', function () {
     eraseHome();
     var v8flags = require('../');
     v8flags(function (err, flags) {
-      expect(flags).toContain('--no_deprecation');
+      expect(flags).toContain('--no-deprecation');
       done();
     });
   });
@@ -197,7 +197,6 @@ describe('v8flags', function () {
       expect(flags).not.toContain('--exec');
       expect(flags).not.toContain('--print');
       expect(flags).not.toContain('--interactive');
-      expect(flags).not.toContain('--require');
       expect(flags).not.toContain('--version');
       done();
     });


### PR DESCRIPTION
Closes #51

This utilizes `process.allowedNodeEnvironmentFlags` to provide the node flags to the end user, instead of spawning an extra process. We still need to spawn a process for `--v8-options` until node core adds an API for that.

This is marked as "breaking" because `--require` now shows up in the output and the flags are only available as `-` separated.

I also cleaned up some of the parallelization code.