### PR TITLE
chore: Cleanup for newer node versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,19 +115,7 @@ function getFlags(cb) {
 // with both the error and the data that was meant to be written.
 function writeConfig(fd, flags, cb) {
   var json = JSON.stringify(flags);
-  var buf;
-  if (Buffer.from && Buffer.from !== Uint8Array.from) {
-    // Node.js 4.5.0 or newer
-    buf = Buffer.from(json);
-  } else {
-    // Old Node.js versions
-    // The typeof safeguard below is mostly against accidental copy-pasting
-    // and code rewrite, it never happens as json is always a string here.
-    if (typeof json === 'number') {
-      throw new Error('Unexpected type number');
-    }
-    buf = new Buffer(json);
-  }
+  var buf = Buffer.from(json);
   return fs.write(fd, buf, 0, buf.length, 0, function (writeErr) {
     fs.close(fd, function (closeErr) {
       var err = writeErr || closeErr;

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var execFile = require('child_process').execFile;
 var configPath = require('./config-path.js')(process.platform);
 var env = process.env;
 var user = env.LOGNAME || env.USER || env.LNAME || env.USERNAME || '';
-var exclusions = ['--help', '--completion_bash'];
+var exclusions = ['--help', '--completion-bash'];
 
 // This number must be incremented whenever the generated cache file changes.
 var CACHE_VERSION = 3;
@@ -72,12 +72,8 @@ function tryOpenConfig(configpath, cb) {
   }
 }
 
-// Node <= 9 outputs _ in flags with multiple words, while node 10
-// uses -. Both ways are accepted anyway, so always use `_` for better
-// compatibility.
-// We must not replace the first two --.
 function normalizeFlagName(flag) {
-  return '--' + flag.slice(4).replace(/-/g, '_');
+  return flag.trim();
 }
 
 // i can't wait for the day this whole module is obsolete because these

--- a/test/index.js
+++ b/test/index.js
@@ -138,6 +138,28 @@ describe('v8flags', function () {
     });
   });
 
+  it('fails with an error if the CLI crashes', function (done) {
+    if (os.platform() === 'win32') {
+      this.skip();
+    }
+
+    eraseHome();
+    var v8flags = require('../');
+
+    // Save original execPath
+    var execPath = process.execPath;
+    // Set execPath to our fake-bin
+    process.execPath = __dirname + '/throw-bin';
+
+    v8flags(function (err, flags) {
+      expect(err).not.toBeNull();
+      expect(flags).toBeUndefined();
+      // Restore original execPath
+      process.execPath = execPath;
+      done();
+    });
+  });
+
   it('should back with an empty array if the runtime is electron', function (done) {
     process.versions.electron = 'set';
     var v8flags = require('../');

--- a/test/index.js
+++ b/test/index.js
@@ -166,7 +166,7 @@ describe('v8flags', function () {
     eraseHome();
     var v8flags = require('../');
     v8flags(function (err, flags) {
-      expect(flags).toContain('--expose_gc_as');
+      expect(flags).toContain('--expose-gc-as');
       done();
     });
   });
@@ -197,6 +197,9 @@ describe('v8flags', function () {
       expect(flags).not.toContain('--print');
       expect(flags).not.toContain('--interactive');
       expect(flags).not.toContain('--version');
+      // Exclusions
+      expect(flags).not.toContain('--completion-bash');
+      expect(flags).not.toContain('--help');
       done();
     });
   });

--- a/test/throw-bin
+++ b/test/throw-bin
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+throw new Error("Boom");


### PR DESCRIPTION
I went through the code and removed some cruft that we had to support old versions of node. There's actually a breaking change in here because we no longer support snake_case flags.